### PR TITLE
Downgrade OpenJDK to v8, to avoid "Server VM is only supported on ARM…

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -36,7 +36,7 @@ apt-get install -qy --no-install-recommends \
     dirmngr \
     gpg \
     gpg-agent \
-    openjdk-11-jre-headless \
+    openjdk-8-jre-headless \
     procps \
     libcap2-bin \
     tzdata


### PR DESCRIPTION
Related article: [raspberry-pi-server-vm-is-only-supported-on-armv7-vfp-error](https://mathematica.stackexchange.com/questions/218347/raspberry-pi-server-vm-is-only-supported-on-armv7-vfp-error) 