### PR TITLE
Install Java 11 from Zulu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM balenalib/raspberry-pi-golang:1-buster-build as permset
+FROM balenalib/raspberry-pi-golang:1-bullseye-build as permset
 
 WORKDIR /src
 RUN git clone https://github.com/jacobalberty/permset.git /src && \
     mkdir -p /out && \
     go build -ldflags "-X main.chownDir=/unifi" -o /out/permset
 
-FROM navikey/raspbian-buster:latest
+FROM navikey/raspbian-bullseye:latest
 
 LABEL maintainer="chopeen"
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -36,10 +36,20 @@ apt-get install -qy --no-install-recommends \
     dirmngr \
     gpg \
     gpg-agent \
-    openjdk-8-jre-headless \
     procps \
     libcap2-bin \
     tzdata
+
+# starting from v7.3, Unifi Controller drops support for Java 8 and requires Java 11
+# https://jjn.one/posts/raspberry-pi-zero-java-11/
+cd /usr/lib/jvm
+wget https://cdn.azul.com/zulu-embedded/bin/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
+tar -xzvf zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
+rm zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
+update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf/bin/java 10
+update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf/bin/javac 10
+update-alternatives --config java
+
 echo 'deb https://www.ui.com/downloads/unifi/debian stable ubiquiti' | tee /etc/apt/sources.list.d/100-ubnt-unifi.list
 tryfail apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 06E85760C0A52C50
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -44,7 +44,7 @@ apt-get install -qy --no-install-recommends \
 # https://jjn.one/posts/raspberry-pi-zero-java-11/
 mkdir -p /usr/lib/jvm
 cd /usr/lib/jvm
-wget https://cdn.azul.com/zulu-embedded/bin/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
+wget --quiet https://cdn.azul.com/zulu-embedded/bin/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
 tar -xzvf zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
 rm zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
 update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf/bin/java 10

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -42,6 +42,7 @@ apt-get install -qy --no-install-recommends \
 
 # starting from v7.3, Unifi Controller drops support for Java 8 and requires Java 11
 # https://jjn.one/posts/raspberry-pi-zero-java-11/
+mkdir -p /usr/lib/jvm
 cd /usr/lib/jvm
 wget https://cdn.azul.com/zulu-embedded/bin/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz
 tar -xzvf zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf.tar.gz

--- a/functions
+++ b/functions
@@ -5,13 +5,8 @@ log() {
 }
 
 set_java_home() {
-    JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/jre/bin/java::")
-    if [ ! -d "${JAVA_HOME}" ]; then
-        # For some reason readlink failed so lets just make some assumptions instead
-        # We're assuming openjdk 8 since thats what we install in Dockerfile
-        arch=`dpkg --print-architecture 2>/dev/null`
-        JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${arch}
-    fi
+    # hard-coded path to unpacked Zulu Java
+    JAVA_HOME=/usr/lib/jvm/zulu11.62.17-ca-jdk11.0.18-linux_aarch32hf
 }
 
 instPkg() {


### PR DESCRIPTION
Starting from v7.3, Unifi Controller drops support for Java 8 and requires Java 11:

- https://community.ui.com/releases/UniFi-Network-Application-7-2-97/d2f71152-3001-42cd-834c-9245d86f4e72
- https://community.ui.com/releases/UniFi-Network-Application-7-3-83/88f5ff3f-4c13-45e2-b57e-ad04b4140528

According to https://jjn.one/posts/raspberry-pi-zero-java-11/, it is possible to install [Java JDK 11 for ARMv6 provided by Azul called Zulu SDK](https://www.azul.com/downloads/?architecture=arm-32-bit-hf&package=jdk).